### PR TITLE
3. Use conversion from openapi spec to build utcp tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ graph TB
     end
     
     %% AI Agent Interactions
-    A -->|1. Discover Tools<br/>(No Auth)| B
+    A -->|1. Discover Tools No Auth| B
     A -->|2. Authenticate| H
-    A -->|3. Discover All Tools<br/>(With JWT)| B
+    A -->|3. Discover All Tools With JWT| B
     A -->|4. Execute Public Tool| C
-    A -->|5. Execute Protected Tool<br/>(With JWT)| D
+    A -->|5. Execute Protected Tool With JWT| D
     
     %% Internal Connections
     B --> E
@@ -70,10 +70,10 @@ graph TB
     E -->|Verify JWT| H
     
     %% Response Flow
-    E -->|Unauthenticated:<br/>1 Public Tool| A
-    E -->|Authenticated:<br/>2 Tools (Public + Protected)| A
-    F -->|"Hello Unprotected Space!"| A
-    G -->|"Hello Protected Space!"| A
+    E -->|Unauthenticated: 1 Public Tool| A
+    E -->|Authenticated: 2 Tools Public + Protected| A
+    F -->|Hello Unprotected Space!| A
+    G -->|Hello Protected Space!| A
     
     %% Styling
     classDef aiAgent fill:#e1f5fe

--- a/README.md
+++ b/README.md
@@ -66,23 +66,34 @@ Important: this application uses various AWS services and there are costs associ
 
 ## How it works
 
-This pattern demonstrates enterprise-grade AI agent integration with tiered discovery by:
+This pattern demonstrates enterprise-grade AI agent integration with tiered discovery using **OpenAPI-driven UTCP generation**:
 
-1. **Tiered API Discovery**: AI agents call the `/utcp` endpoint to discover available tools based on their authentication status
-2. **Progressive Authentication**: Unauthenticated agents discover public tools; authenticated agents discover all tools
-3. **Tool Execution**: Agents call the actual API endpoints using the discovered tool definitions
-4. **Standardized Response**: All interactions follow UTCP protocol standards
+1. **OpenAPI Specifications**: API endpoints are defined using industry-standard OpenAPI 3.0 specifications
+2. **Dynamic UTCP Generation**: The `/utcp` endpoint uses the official UTCP SDK's `OpenApiConverter` to transform OpenAPI specs into UTCP tool definitions at runtime
+3. **Tiered API Discovery**: AI agents call the `/utcp` endpoint to discover available tools based on their authentication status
+4. **Progressive Authentication**: Unauthenticated agents discover public tools; authenticated agents discover all tools
+5. **Tool Execution**: Agents call the actual API endpoints using the discovered tool definitions
+6. **Standardized Response**: All interactions follow UTCP protocol standards
 
 The pattern includes:
 - **Unprotected endpoint** (`/unprotected`): Demonstrates public API integration
 - **Protected endpoint** (`/protected`): Shows secure API access with JWT authentication
 - **UTCP endpoint** (`/utcp`): Provides tiered tool discovery for AI agents (public endpoint with internal auth logic)
 
+### OpenAPI-Driven Architecture Benefits:
+
+- **Single Source of Truth**: API definitions are maintained in OpenAPI format
+- **Industry Standard**: Uses OpenAPI 3.0 specifications for API documentation
+- **Automatic UTCP Generation**: Tools are generated dynamically from OpenAPI specs
+- **Easy Maintenance**: Update OpenAPI specs, UTCP tools update automatically
+- **Better Tooling**: Supports Swagger UI, validation, and other OpenAPI tools
+- **Scalable**: Easy to add new endpoints by updating OpenAPI specifications
+
 The UTCP endpoint implements tiered discovery:
 - **Without authentication**: Returns only public tools (e.g., `get_unprotected_data`)
 - **With JWT authentication**: Returns all tools (public + protected, e.g., `get_unprotected_data` + `get_protected_data`)
 
-Each API endpoint is automatically described in the UTCP manual with proper authentication requirements, input/output schemas, and execution details.
+Each API endpoint is automatically described in the UTCP manual with proper authentication requirements, input/output schemas, and execution details derived from the OpenAPI specifications.
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -39,18 +39,18 @@ graph TB
         end
         
         subgraph "AWS Lambda Functions"
-            E["UTCP Lambda<br/>OpenAPI → UTCP Converter"]
-            F["Unprotected Lambda<br/>Public Business Logic"]
-            G["Protected Lambda<br/>Secure Business Logic"]
+            E[UTCP Lambda<br/>OpenAPI → UTCP Converter]
+            F[Unprotected Lambda<br/>Public Business Logic]
+            G[Protected Lambda<br/>Secure Business Logic]
         end
         
         subgraph "Amazon Cognito"
-            H["User Pool<br/>JWT Authentication"]
+            H[User Pool<br/>JWT Authentication]
         end
         
         subgraph "OpenAPI Specifications"
-            I["Embedded OpenAPI 3.0<br/>Unprotected APIs"]
-            J["Embedded OpenAPI 3.0<br/>Protected APIs"]
+            I[Embedded OpenAPI 3.0<br/>Unprotected APIs]
+            J[Embedded OpenAPI 3.0<br/>Protected APIs]
         end
     end
     

--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ graph TB
     E -->|Verify JWT| H
     
     %% Response Flow
-    E -->|Unauthenticated: 1 Public Tool| A
-    E -->|Authenticated: 2 Tools Public + Protected| A
+    E -->|Unauthenticated - 1 Public Tool| A
+    E -->|Authenticated - 2 Tools Public + Protected| A
     F -->|Hello Unprotected Space!| A
     G -->|Hello Protected Space!| A
     

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ graph TB
     end
     
     %% AI Agent Interactions
-    A -->|1. Discover Tools No Auth| B
-    A -->|2. Authenticate| H
-    A -->|3. Discover All Tools With JWT| B
-    A -->|4. Execute Public Tool| C
-    A -->|5. Execute Protected Tool With JWT| D
+    A -->|1 - Discover Tools No Auth| B
+    A -->|2 - Authenticate| H
+    A -->|3 - Discover All Tools With JWT| B
+    A -->|4 - Execute Public Tool| C
+    A -->|5 -Execute Protected Tool With JWT| D
     
     %% Internal Connections
     B --> E
@@ -70,8 +70,8 @@ graph TB
     E -->|Verify JWT| H
     
     %% Response Flow
-    E -->|Unauthenticated - 1 Public Tool| A
-    E -->|Authenticated - 2 Tools Public + Protected| A
+    E -->|Unauthenticated: 1 Public Tool| A
+    E -->|Authenticated: 2 Tools Public + Protected| A
     F -->|Hello Unprotected Space!| A
     G -->|Hello Protected Space!| A
     

--- a/README.md
+++ b/README.md
@@ -83,16 +83,28 @@ Each API endpoint is automatically described in the UTCP manual with proper auth
 ## Testing
 
 **Pre-requisites**
-1. Update the variables with the outputs of your stack.
+1. Export the variables with the outputs of your stack.
    ```bash
-     API_URL="<your api URL>"    
-     POOL_ID="<your pool ID>" 
-     CLIENT_ID="<your client ID>" 
+     # Get the stack name (adjust the filter if your stack has a different naming pattern)
+     export STACK_NAME=$(aws cloudformation list-stacks --stack-status-filter CREATE_COMPLETE UPDATE_COMPLETE --query 'StackSummaries[?contains(StackName, `Transform`) || contains(StackName, `Utcp`) || contains(StackName, `Api`)].StackName' --output text)
+     
+     # Extract values from CloudFormation stack outputs
+     export API_URL=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`HttpApiURL`].OutputValue' --output text)
+     export POOL_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`UserPoolId`].OutputValue' --output text)
+     export CLIENT_ID=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query 'Stacks[0].Outputs[?OutputKey==`UserPoolClientId`].OutputValue' --output text)
+     
+     # Export the AWS region (needed for Python script)
+     export AWS_DEFAULT_REGION=$(aws configure get region)
+
+     echo "API_URL: $API_URL"
+     echo "POOL_ID: $POOL_ID"
+     echo "CLIENT_ID: $CLIENT_ID"
+     echo "AWS_DEFAULT_REGION: $AWS_DEFAULT_REGION"
    ```
-2. Set the variables for the fake user to be created
+2. Export the variables for the fake user to be created
    ```bash
-     EMAIL="fake@example.com"                                
-     PASSWORD="S3cuRe#FaKE*"
+     export EMAIL="fake@example.com"                                
+     export PASSWORD="S3cuRe#FaKE*"
    ```
 
 **Unprotected endpoint**

--- a/lib/http-api-cognito-lambda-stack.ts
+++ b/lib/http-api-cognito-lambda-stack.ts
@@ -28,21 +28,30 @@ export class HttpApiCognitoLambdaStack extends Stack {
     const unprotectedFn = new NodejsFunction(this, 'unprotectedFn', {
       runtime: Runtime.NODEJS_20_X,
       entry: path.join(__dirname, '/../resources/unprotected-fn.ts'),
-      handler: 'handler'
+      handler: 'handler',
+      bundling: {
+        forceDockerBundling: false,
+      }
     })
 
     // Protected Accessible Lambda
     const protectedFn = new NodejsFunction(this, 'protectedFn', {
       runtime: Runtime.NODEJS_20_X,
       entry: path.join(__dirname, '/../resources/protected-fn.ts'),
-      handler: 'handler'
+      handler: 'handler',
+      bundling: {
+        forceDockerBundling: false,
+      }
     })
 
     // UTCP Manual Lambda
     const utcpFn = new NodejsFunction(this, 'utcpFn', {
       runtime: Runtime.NODEJS_20_X,
       entry: path.join(__dirname, '/../resources/utcp-fn.ts'),
-      handler: 'handler'
+      handler: 'handler',
+      bundling: {
+        forceDockerBundling: false,
+      }
     })
 
     // HTTP API Gateway

--- a/lib/http-api-cognito-lambda-stack.ts
+++ b/lib/http-api-cognito-lambda-stack.ts
@@ -79,11 +79,13 @@ export class HttpApiCognitoLambdaStack extends Stack {
       path:'/utcp',
       methods: [ HttpMethod.GET ],
       integration: new HttpLambdaIntegration('utcpIntegration', utcpFn),
-      authorizer: jwtAuthorizer
+      authorizer: undefined  // No authorizer - endpoint is now public but function handles auth internally
     })
 
-    // Set API URL environment variable for UTCP function
+    // Set environment variables for UTCP function
     utcpFn.addEnvironment('API_URL', httpApi.url ?? '');
+    utcpFn.addEnvironment('USER_POOL_ID', userPool.userPoolId);
+    utcpFn.addEnvironment('CLIENT_ID', userPoolClient.userPoolClientId);
 
     // Outputs
     new CfnOutput(this, "HttpApi URL", {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,9 @@
       "dependencies": {
         "@types/aws-lambda": "^8.10.136",
         "aws-cdk-lib": "^2.185.0",
+        "aws-jwt-verify": "^4.0.1",
         "constructs": "^10.0.0",
+        "esbuild": "^0.25.8",
         "source-map-support": "^0.5.21"
       },
       "bin": {
@@ -82,6 +84,422 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
+      "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@jridgewell/resolve-uri": {
@@ -555,6 +973,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/aws-jwt-verify": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/aws-jwt-verify/-/aws-jwt-verify-4.0.1.tgz",
+      "integrity": "sha512-kzvi71eD3w/mCpYRUY7cz6DX4bfYihGdI2yV3FYQ2JuZZenqAqDPz0gWj0ew6vlAtdEVBNb7p+Dm2TAIxpVYMA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -582,6 +1009,47 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
+      "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.8",
+        "@esbuild/android-arm": "0.25.8",
+        "@esbuild/android-arm64": "0.25.8",
+        "@esbuild/android-x64": "0.25.8",
+        "@esbuild/darwin-arm64": "0.25.8",
+        "@esbuild/darwin-x64": "0.25.8",
+        "@esbuild/freebsd-arm64": "0.25.8",
+        "@esbuild/freebsd-x64": "0.25.8",
+        "@esbuild/linux-arm": "0.25.8",
+        "@esbuild/linux-arm64": "0.25.8",
+        "@esbuild/linux-ia32": "0.25.8",
+        "@esbuild/linux-loong64": "0.25.8",
+        "@esbuild/linux-mips64el": "0.25.8",
+        "@esbuild/linux-ppc64": "0.25.8",
+        "@esbuild/linux-riscv64": "0.25.8",
+        "@esbuild/linux-s390x": "0.25.8",
+        "@esbuild/linux-x64": "0.25.8",
+        "@esbuild/netbsd-arm64": "0.25.8",
+        "@esbuild/netbsd-x64": "0.25.8",
+        "@esbuild/openbsd-arm64": "0.25.8",
+        "@esbuild/openbsd-x64": "0.25.8",
+        "@esbuild/openharmony-arm64": "0.25.8",
+        "@esbuild/sunos-x64": "0.25.8",
+        "@esbuild/win32-arm64": "0.25.8",
+        "@esbuild/win32-ia32": "0.25.8",
+        "@esbuild/win32-x64": "0.25.8"
       }
     },
     "node_modules/fsevents": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@types/aws-lambda": "^8.10.136",
+        "@utcp/sdk": "^0.1.1",
         "aws-cdk-lib": "^2.185.0",
         "aws-jwt-verify": "^4.0.1",
         "constructs": "^10.0.0",
@@ -502,6 +503,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/@graphql-typed-document-node/core": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
+      "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
@@ -574,6 +584,27 @@
         "undici-types": "~5.26.4"
       }
     },
+    "node_modules/@utcp/sdk": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@utcp/sdk/-/sdk-0.1.1.tgz",
+      "integrity": "sha512-qjzY95z04wLrIREOdKnVgMHOQ4FzXRxBztwalw9PGEzUhYVm0yC1j3SLfTDKJ71F2ZplPAgad7wN2bX5DB/3+g==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axios": "^1.6.0",
+        "dotenv": "^17.1.0",
+        "eventsource": "^2.0.2",
+        "graphql": "^16.8.1",
+        "graphql-request": "^6.1.0",
+        "js-yaml": "^4.1.0",
+        "tozod": "^3.0.0",
+        "ws": "^8.14.2",
+        "zod": "^3.22.4",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -605,6 +636,18 @@
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
       "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT"
     },
     "node_modules/aws-cdk": {
@@ -982,11 +1025,47 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/axios": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
+      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.4",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/constructs": {
       "version": "10.4.2",
@@ -1001,6 +1080,24 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
@@ -1009,6 +1106,77 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/esbuild": {
@@ -1052,6 +1220,51 @@
         "@esbuild/win32-x64": "0.25.8"
       }
     },
+    "node_modules/eventsource": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-2.0.2.tgz",
+      "integrity": "sha512-IzUmBGPR3+oUG9dUeXynyNmf91/3zUSJg1lCktzKw47OXuhco54U3r9B7O4XX+Rb1Itm9OZ2b0RkTs10bICOxA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
+      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
@@ -1067,12 +1280,199 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graphql": {
+      "version": "16.11.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
+      "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-6.1.0.tgz",
+      "integrity": "sha512-p+XPfS4q7aIpKVcgmnZKhMNqhltk20hfXtkaIkTfjjmiKMJ5xrt5c743cL03y/K7y1rg3WrIC49xGiEQ4mxdNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@graphql-typed-document-node/core": "^3.2.0",
+        "cross-fetch": "^3.1.5"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
       "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -1092,6 +1492,21 @@
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
       }
+    },
+    "node_modules/tozod": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tozod/-/tozod-3.0.0.tgz",
+      "integrity": "sha512-R03/moNPEGgWKoTdCsEJuyEoP6NtXyhWg9L9lJhF2XyCR2Ce9XE+yXaswaVmqyBpHsRPC2Pk38mK8Ex7iHaXcg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "zod": "^3.0.0-alpha.2"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/ts-node": {
       "version": "10.9.2",
@@ -1165,6 +1580,43 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
+      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
@@ -1173,6 +1625,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.24.6",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.24.6.tgz",
+      "integrity": "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@types/aws-lambda": "^8.10.136",
     "aws-cdk-lib": "^2.185.0",
+    "aws-jwt-verify": "^4.0.1",
     "constructs": "^10.0.0",
     "esbuild": "^0.25.8",
     "source-map-support": "^0.5.21"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@types/aws-lambda": "^8.10.136",
+    "@utcp/sdk": "^0.1.1",
     "aws-cdk-lib": "^2.185.0",
     "aws-jwt-verify": "^4.0.1",
     "constructs": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@types/aws-lambda": "^8.10.136",
     "aws-cdk-lib": "^2.185.0",
     "constructs": "^10.0.0",
+    "esbuild": "^0.25.8",
     "source-map-support": "^0.5.21"
   }
 }

--- a/resources/utcp-fn.ts
+++ b/resources/utcp-fn.ts
@@ -1,51 +1,150 @@
 import { APIGatewayProxyEventV2, APIGatewayProxyResultV2 } from 'aws-lambda';
 import { CognitoJwtVerifier } from 'aws-jwt-verify';
+import { OpenApiConverter } from '@utcp/sdk/dist/src/client/openapi-converter';
+import { UtcpManual, UtcpManualSchema } from '@utcp/sdk/dist/src/shared/utcp-manual';
+import { Tool } from '@utcp/sdk/dist/src/shared/tool';
 
-// UTCP Types (from typescript-utcp repository)
-interface ToolInputOutputSchema {
-  type: string;
-  properties: Record<string, any>;
-  required?: string[];
-  description?: string;
-  title?: string;
-  items?: Record<string, any>;
-  enum?: any[];
-  minimum?: number;
-  maximum?: number;
-  format?: string;
-}
+// Package version
+const PACKAGE_VERSION = '0.1.1';
 
-interface HttpProvider {
-  name?: string;
-  provider_type: 'http';
-  http_method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
-  url: string;
-  content_type: string;
-  auth?: {
-    auth_type: 'api_key';
-    api_key: string;
-    var_name: string;
-    location: 'header' | 'query' | 'cookie';
-  };
-  headers?: Record<string, string>;
-  body_field?: string;
-  header_fields?: string[];
-}
+// OpenAPI specifications (embedded as JSON)
+const unprotectedApiSpec = {
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Unprotected API",
+    "description": "Public endpoints that don't require authentication",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "{baseUrl}"
+    }
+  ],
+  "paths": {
+    "/unprotected": {
+      "get": {
+        "operationId": "get_unprotected_data",
+        "summary": "Get data from unprotected endpoint",
+        "description": "Retrieve data from a public endpoint that doesn't require authentication",
+        "tags": ["public", "unprotected", "api"],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "description": "Response message",
+                  "example": "Hello Unprotected Space!"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
 
-interface Tool {
-  name: string;
-  description: string;
-  inputs: ToolInputOutputSchema;
-  outputs: ToolInputOutputSchema;
-  tags: string[];
-  average_response_size?: number;
-  tool_provider: HttpProvider;
-}
-
-interface UtcpManual {
-  version: string;
-  tools: Tool[];
-}
+const protectedApiSpec = {
+  "openapi": "3.0.3",
+  "info": {
+    "title": "Protected API",
+    "description": "Secure endpoints that require JWT authentication",
+    "version": "1.0.0"
+  },
+  "servers": [
+    {
+      "url": "{baseUrl}"
+    }
+  ],
+  "paths": {
+    "/protected": {
+      "get": {
+        "operationId": "get_protected_data",
+        "summary": "Get data from protected endpoint",
+        "description": "Retrieve data from a secure endpoint that requires JWT authentication",
+        "tags": ["protected", "jwt", "auth", "api"],
+        "security": [
+          {
+            "JWTAuth": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "Authorization",
+            "in": "header",
+            "required": true,
+            "description": "JWT Bearer token for authentication",
+            "schema": {
+              "type": "string",
+              "pattern": "^Bearer .+",
+              "example": "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9..."
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "type": "string",
+                  "description": "Response message",
+                  "example": "Hello Protected Space!"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized - Invalid or missing JWT token",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "description": "Error message"
+                    }
+                  },
+                  "required": ["error"]
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "securitySchemes": {
+      "JWTAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT",
+        "description": "JWT token obtained from Cognito authentication"
+      }
+    }
+  }
+};
 
 // Initialize JWT verifier (will be configured with environment variables)
 let jwtVerifier: CognitoJwtVerifier | null = null;
@@ -81,6 +180,14 @@ async function isAuthenticated(event: APIGatewayProxyEventV2): Promise<boolean> 
   }
 }
 
+function updateApiSpecWithBaseUrl(spec: any, baseUrl: string): any {
+  const updatedSpec = JSON.parse(JSON.stringify(spec)); // Deep clone
+  if (updatedSpec.servers && updatedSpec.servers[0]) {
+    updatedSpec.servers[0].url = baseUrl;
+  }
+  return updatedSpec;
+}
+
 export async function handler(event: APIGatewayProxyEventV2): Promise<APIGatewayProxyResultV2> {
   console.log(`Event: ${JSON.stringify(event, null, 2)}`);
   
@@ -89,89 +196,58 @@ export async function handler(event: APIGatewayProxyEventV2): Promise<APIGateway
   
   console.log(`Request authenticated: ${authenticated}`);
 
-  // Define unprotected tools (always available)
-  const unprotectedTools: Tool[] = [
-    {
-      name: 'get_unprotected_data',
-      description: 'Get data from the unprotected endpoint',
-      inputs: {
-        type: 'object',
-        properties: {},
-        required: []
-      },
-      outputs: {
-        type: 'object',
-        properties: {
-          message: { type: 'string', description: 'Response message' }
-        },
-        required: ['message']
-      },
-      tags: ['api', 'unprotected', 'public'],
-      tool_provider: {
-        name: 'unprotected_provider',
-        provider_type: 'http',
-        http_method: 'GET',
-        url: `${apiUrl}/unprotected`,
-        content_type: 'application/json'
-      }
+  try {
+    // Update API specs with the actual base URL
+    const updatedUnprotectedSpec = updateApiSpecWithBaseUrl(unprotectedApiSpec, apiUrl);
+    
+    // Convert unprotected OpenAPI spec to UTCP tools
+    const unprotectedConverter = new OpenApiConverter(updatedUnprotectedSpec, {
+      providerName: 'unprotected_provider'
+    });
+    const unprotectedManual = unprotectedConverter.convert();
+
+    let allTools: Tool[] = [...unprotectedManual.tools];
+
+    // If authenticated, also include protected tools
+    if (authenticated) {
+      const updatedProtectedSpec = updateApiSpecWithBaseUrl(protectedApiSpec, apiUrl);
+      const protectedConverter = new OpenApiConverter(updatedProtectedSpec, {
+        providerName: 'protected_provider'
+      });
+      const protectedManual = protectedConverter.convert();
+      allTools = [...allTools, ...protectedManual.tools];
     }
-  ];
 
-  // Define protected tools (only available when authenticated)
-  const protectedTools: Tool[] = [
-    {
-      name: 'get_protected_data',
-      description: 'Get data from the protected endpoint (requires JWT authentication)',
-      inputs: {
-        type: 'object',
-        properties: {
-          authorization: { 
-            type: 'string', 
-            description: 'JWT token for authentication (Bearer token format)' 
-          }
-        },
-        required: ['authorization']
+    // Construct the UTCP manual following the library pattern
+    const manual: UtcpManual = UtcpManualSchema.parse({
+      version: PACKAGE_VERSION,
+      tools: allTools
+    });
+
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+        'X-Auth-Status': authenticated ? 'authenticated' : 'unauthenticated',
+        'X-Tools-Count': allTools.length.toString()
       },
-      outputs: {
-        type: 'object',
-        properties: {
-          message: { type: 'string', description: 'Response message' }
-        },
-        required: ['message']
+      body: JSON.stringify(manual, null, 2)
+    };
+
+  } catch (error) {
+    console.error('Error generating UTCP manual:', error);
+    
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*'
       },
-      tags: ['api', 'protected', 'jwt', 'auth'],
-      tool_provider: {
-        name: 'protected_provider',
-        provider_type: 'http',
-        http_method: 'GET',
-        url: `${apiUrl}/protected`,
-        content_type: 'application/json',
-        auth: {
-          auth_type: 'api_key',
-          api_key: '$authorization',
-          var_name: 'Authorization',
-          location: 'header'
-        }
-      }
-    }
-  ];
-
-  // Return tools based on authentication status
-  const tools = authenticated ? [...unprotectedTools, ...protectedTools] : unprotectedTools;
-
-  const manual: UtcpManual = {
-    version: '0.1.1',
-    tools
-  };
-
-  return {
-    statusCode: 200,
-    headers: {
-      'Content-Type': 'application/json',
-      'Access-Control-Allow-Origin': '*',
-      'X-Auth-Status': authenticated ? 'authenticated' : 'unauthenticated',
-      'X-Tools-Count': tools.length.toString()
-    },
-    body: JSON.stringify(manual, null, 2)
-  };
+      body: JSON.stringify({
+        error: 'Internal server error',
+        message: 'Failed to generate UTCP manual'
+      })
+    };
+  }
 }

--- a/test_claude_bedrock.py
+++ b/test_claude_bedrock.py
@@ -2,13 +2,14 @@ import boto3
 import requests
 import json
 
-# Configuration
-API_URL = "https://7xkzkojyfi.execute-api.us-east-1.amazonaws.com/"  # Replace with your API URL
-REGION = "us-east-1"  # Replace with your region
-POOL_ID = "us-east-1_Wmwra3jGh"  # Replace with your Cognito User Pool ID
-CLIENT_ID = "2oq563ge84k0upqmbgdsm6hu07"  # Replace with your Cognito Client ID
-EMAIL = "fake@example.com"
-PASSWORD = "S3cuRe#FaKE*"
+# Configuration - using environment variables
+import os
+API_URL = os.environ.get('API_URL')
+REGION = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')  # Use AWS default region or fallback
+POOL_ID = os.environ.get('POOL_ID')
+CLIENT_ID = os.environ.get('CLIENT_ID')
+EMAIL = os.environ.get('EMAIL')
+PASSWORD = os.environ.get('PASSWORD')
 
 def get_jwt_token():
     """Get JWT token from Cognito"""

--- a/test_tiered_discovery.py
+++ b/test_tiered_discovery.py
@@ -1,0 +1,217 @@
+import boto3
+import requests
+import json
+import os
+
+# Configuration - using environment variables
+API_URL = os.environ.get('API_URL')
+REGION = os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')
+POOL_ID = os.environ.get('POOL_ID')
+CLIENT_ID = os.environ.get('CLIENT_ID')
+EMAIL = os.environ.get('EMAIL')
+PASSWORD = os.environ.get('PASSWORD')
+
+def get_jwt_token():
+    """Get JWT token from Cognito"""
+    cognito = boto3.client('cognito-idp', region_name=REGION)
+    
+    try:
+        response = cognito.initiate_auth(
+            ClientId=CLIENT_ID,
+            AuthFlow='USER_PASSWORD_AUTH',
+            AuthParameters={
+                'USERNAME': EMAIL,
+                'PASSWORD': PASSWORD
+            }
+        )
+        return response['AuthenticationResult']['AccessToken']
+    except Exception as e:
+        print(f"Error getting token: {e}")
+        return None
+
+def discover_tools_unauthenticated():
+    """Discover tools without authentication"""
+    print("🔍 DISCOVERING TOOLS WITHOUT AUTHENTICATION...")
+    try:
+        response = requests.get(f"{API_URL}utcp")
+        if response.status_code == 200:
+            utcp_manual = response.json()
+            tools = utcp_manual.get('tools', [])
+            print(f"✅ Discovered {len(tools)} tools (unauthenticated):")
+            for tool in tools:
+                print(f"   - {tool['name']}: {tool['description']}")
+                print(f"     Tags: {', '.join(tool['tags'])}")
+            return utcp_manual
+        else:
+            print(f"❌ Failed to discover tools: {response.status_code}")
+            return None
+    except Exception as e:
+        print(f"❌ Error discovering tools: {e}")
+        return None
+
+def discover_tools_authenticated(jwt_token):
+    """Discover tools with authentication"""
+    print("\n🔐 DISCOVERING TOOLS WITH AUTHENTICATION...")
+    try:
+        headers = {'Authorization': jwt_token}
+        response = requests.get(f"{API_URL}utcp", headers=headers)
+        if response.status_code == 200:
+            utcp_manual = response.json()
+            tools = utcp_manual.get('tools', [])
+            print(f"✅ Discovered {len(tools)} tools (authenticated):")
+            for tool in tools:
+                print(f"   - {tool['name']}: {tool['description']}")
+                print(f"     Tags: {', '.join(tool['tags'])}")
+            return utcp_manual
+        else:
+            print(f"❌ Failed to discover tools: {response.status_code}")
+            return None
+    except Exception as e:
+        print(f"❌ Error discovering tools: {e}")
+        return None
+
+def test_unprotected_tool_without_auth(utcp_manual):
+    """Test calling the unprotected tool without authentication"""
+    print("\n🌐 TESTING UNPROTECTED TOOL (WITHOUT AUTH)...")
+    for tool in utcp_manual['tools']:
+        if tool['name'] == 'get_unprotected_data':
+            provider = tool['tool_provider']
+            try:
+                response = requests.get(provider['url'])
+                if response.status_code == 200:
+                    # Handle both JSON and plain text responses
+                    try:
+                        result = response.json()
+                    except:
+                        result = response.text
+                    print(f"✅ Unprotected tool result (no auth): {result}")
+                    return result
+                else:
+                    print(f"❌ Unprotected tool failed: {response.status_code}")
+            except Exception as e:
+                print(f"❌ Error calling unprotected tool: {e}")
+    return None
+
+def test_unprotected_tool_with_auth(utcp_manual, jwt_token):
+    """Test calling the unprotected tool with authentication"""
+    print("\n🌐 TESTING UNPROTECTED TOOL (WITH AUTH)...")
+    for tool in utcp_manual['tools']:
+        if tool['name'] == 'get_unprotected_data':
+            provider = tool['tool_provider']
+            try:
+                # Test with auth header (should still work)
+                headers = {'Authorization': jwt_token}
+                response = requests.get(provider['url'], headers=headers)
+                if response.status_code == 200:
+                    # Handle both JSON and plain text responses
+                    try:
+                        result = response.json()
+                    except:
+                        result = response.text
+                    print(f"✅ Unprotected tool result (with auth): {result}")
+                    return result
+                else:
+                    print(f"❌ Unprotected tool failed: {response.status_code}")
+            except Exception as e:
+                print(f"❌ Error calling unprotected tool: {e}")
+    return None
+
+def test_protected_tool_without_auth(utcp_manual):
+    """Test calling the protected tool without authentication (should fail)"""
+    print("\n🔒 TESTING PROTECTED TOOL (WITHOUT AUTH - should fail)...")
+    for tool in utcp_manual['tools']:
+        if tool['name'] == 'get_protected_data':
+            provider = tool['tool_provider']
+            try:
+                response = requests.get(provider['url'])
+                if response.status_code == 200:
+                    try:
+                        result = response.json()
+                    except:
+                        result = response.text
+                    print(f"❌ Unexpected success: {result}")
+                    return result
+                else:
+                    print(f"✅ Protected tool correctly rejected (status {response.status_code}): Unauthorized access blocked")
+                    return None
+            except Exception as e:
+                print(f"❌ Error calling protected tool: {e}")
+    return None
+
+def test_protected_tool_with_auth(utcp_manual, jwt_token):
+    """Test calling the protected tool with authentication"""
+    print("\n🔒 TESTING PROTECTED TOOL (WITH AUTH)...")
+    for tool in utcp_manual['tools']:
+        if tool['name'] == 'get_protected_data':
+            provider = tool['tool_provider']
+            try:
+                headers = {'Authorization': jwt_token}
+                response = requests.get(provider['url'], headers=headers)
+                if response.status_code == 200:
+                    # Handle both JSON and plain text responses
+                    try:
+                        result = response.json()
+                    except:
+                        result = response.text
+                    print(f"✅ Protected tool result (with auth): {result}")
+                    return result
+                else:
+                    print(f"❌ Protected tool failed: {response.status_code}")
+            except Exception as e:
+                print(f"❌ Error calling protected tool: {e}")
+    return None
+
+def main():
+    print("🚀 TESTING TIERED DISCOVERY WITH UTCP")
+    print("=" * 50)
+    
+    # Test 1: Discover tools without authentication
+    unauthenticated_manual = discover_tools_unauthenticated()
+    
+    # Test 2: Get JWT token
+    print("\n🎫 GETTING JWT TOKEN...")
+    jwt_token = get_jwt_token()
+    if not jwt_token:
+        print("❌ Failed to get JWT token, stopping test")
+        return
+    print("✅ JWT token obtained successfully")
+    
+    # Test 3: Discover tools with authentication
+    authenticated_manual = discover_tools_authenticated(jwt_token)
+    
+    # Test 4: Compare discovery results
+    print("\n📊 DISCOVERY COMPARISON:")
+    unauth_count = len(unauthenticated_manual['tools']) if unauthenticated_manual else 0
+    auth_count = len(authenticated_manual['tools']) if authenticated_manual else 0
+    print(f"   Unauthenticated: {unauth_count} tools")
+    print(f"   Authenticated: {auth_count} tools")
+    print(f"   Additional tools with auth: {auth_count - unauth_count}")
+    
+    # Test 5: Test unprotected tool without authentication (should work)
+    if unauthenticated_manual:
+        test_unprotected_tool_without_auth(unauthenticated_manual)
+    
+    # Test 6: Test unprotected tool with authentication (should also work)
+    if authenticated_manual:
+        test_unprotected_tool_with_auth(authenticated_manual, jwt_token)
+    
+    # Test 7: Test protected tool without authentication (should fail)
+    if authenticated_manual:  # We need the tool definition from authenticated discovery
+        test_protected_tool_without_auth(authenticated_manual)
+    
+    # Test 8: Test protected tool with authentication (should work)
+    if authenticated_manual:
+        test_protected_tool_with_auth(authenticated_manual, jwt_token)
+    
+    print("\n✨ TIERED DISCOVERY TEST COMPLETE!")
+    print("=" * 50)
+    print("Summary:")
+    print("- Unauthenticated agents can discover public tools only")
+    print("- Authenticated agents can discover all tools (public + protected)")
+    print("- Public tools work with or without authentication")
+    print("- Protected tools require authentication and are hidden from unauthenticated discovery")
+    print("- This enables progressive disclosure and layered security")
+    print("- AI agents get better capabilities as they authenticate")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implement OpenAPI-driven UTCP with tiered discovery
- Add official @utcp/sdk dependency for OpenAPI conversion
- Implement tiered discovery: public tools without auth, all tools with auth
- Embed OpenAPI specifications directly in Lambda function for better performance
- Update UTCP endpoint to be public with internal authentication logic
- Add comprehensive test script (test_tiered_discovery.py) for validation
- Update README with OpenAPI-driven architecture documentation
- Remove unused schema files for cleaner structure

Features:
✅ Progressive tool discovery based on authentication status
✅ Industry-standard OpenAPI 3.0 specifications
✅ Automatic UTCP tool generation from OpenAPI specs
✅ JWT authentication with Cognito integration
✅ Enterprise-ready security model
✅ Zero breaking changes to existing APIs